### PR TITLE
Update rails upper version limit to "< 6.0"

### DIFF
--- a/susanin.gemspec
+++ b/susanin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 5.0.0", "< 5.2"
+  spec.add_dependency "actionpack", ">= 5.0.0", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Next modules are used by this gem:
- active_support/concern
- active_support/core_ext/array
- active_support/dependencies/autoload

There are no changes currently and probably related code will not change in future minor version updates (before 6.0).